### PR TITLE
fix: render math equations correctly with KaTeX

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,7 +10,7 @@ export default defineConfig({
   markdown: {
     shikiConfig: { theme: 'github-light' },
     remarkPlugins: [remarkMath],
-    rehypePlugins: [rehypeKatex],
+    rehypePlugins: [[rehypeKatex, { throwOnError: true, strict: 'error' }]],
   },
   vite: {
     plugins: [tailwindcss()],

--- a/src/components/MetaInfo.astro
+++ b/src/components/MetaInfo.astro
@@ -51,8 +51,6 @@ const gtagId = 'G-2J02VX8BR7';
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter+Display:ital,wght@0,400..700;1,400..700&family=Libre+Bodoni:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css" integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP" crossorigin="anonymous" />
-
 {isProd && (
   <>
     <script async src={`https://www.googletagmanager.com/gtag/js?id=${gtagId}`}></script>

--- a/src/content/machine-learning/evaluate-object-detection-models.md
+++ b/src/content/machine-learning/evaluate-object-detection-models.md
@@ -38,9 +38,9 @@ As its name indicates, IoU is the ratio between the area of intersection and the
 
 IoU is stemmed from the Jaccard Index, a coefficient measure the similarity between two finite sample sets.
 
-<div class="block-equation">
-  $$J \left( b, \hat{b} \right) = \mathrm{IoU} = \displaystyle \frac{\mathrm{area} \left( b \cap \hat{b} \right)}{\mathrm{area} \left( b \cup \hat{b} \right)}$$
-</div>
+$$
+J \left( b, \hat{b} \right) = \mathrm{IoU} = \displaystyle \frac{\mathrm{area} \left( b \cap \hat{b} \right)}{\mathrm{area} \left( b \cup \hat{b} \right)}
+$$
 
 IoU varies between $$0$$ and $$1$$. An $$\mathrm{IoU} = 1$$ means a perfect match between prediction and ground-truth, while $$\mathrm{IoU} = 0$$ means the predicted and the ground-truth boxes do not overlap. By varying the threshold $$\mathrm{IoU} = \epsilon$$ we can control how restrictive or relaxing the metric is. Moreover, this threshold is used to decide if a detection is correct or not. A correct, or positive, detection has $$\mathrm{IoU} \geq \epsilon$$, otherwise, the detection is an incorrect, or negative one. More formally, predictions are classified as **True Positive** (TP), **False Positive** (FP) and **False Negative** (FN)
 
@@ -58,17 +58,21 @@ In the leftmost illustration of a TP example, there is a ground-truth box of the
 ## Precision and Recall
 
 **Precision** reflects how well a model is in predicting bounding boxes that match ground-truth boxes, i.e. making positive predictions. It is the ratio between number of TP(s) to total number of positive predictions.
-<div class="block-equation">
-  $$\mathrm{Pr} = \displaystyle \frac{\mathrm{TP}}{\mathrm{TP} + \mathrm{FP}} = \frac{\mathrm{TP}}{\text{all detections}}$$
-</div>
+
+$$
+\mathrm{Pr} = \displaystyle \frac{\mathrm{TP}}{\mathrm{TP} + \mathrm{FP}} = \frac{\mathrm{TP}}{\text{all detections}}
+$$
+
 For example, if a model makes 100 bounding-box predictions for the cats in the dataset, and 90 of them are correct predictions (i.e., each box has an IoU higher than predefined threshold, say $$\epsilon = 0.5$$, w.r.t to its corresponding ground-truth), then the precision of the model for the <code>cat</code> label is 90 percent. Precision is often expressed as percentage, or within the range of $$0$$ to $$1$$.
 
 A low precision indicates that the model makes a lot of FP predictions. In contrast, a high precision is when the model either making lots of TP, or very few FP predictions.
 
 **Recall** is the ratio between the number of TP and the actual number of relevant objects.
-<div class="block-equation">
-  $$\mathrm{Rc} = \displaystyle \frac{\mathrm{TP}}{\mathrm{TP} + \mathrm{FN}} = \frac{\mathrm{TP}}{\text{all ground-truths}}$$
-</div>
+
+$$
+\mathrm{Rc} = \displaystyle \frac{\mathrm{TP}}{\mathrm{TP} + \mathrm{FN}} = \frac{\mathrm{TP}}{\text{all ground-truths}}
+$$
+
 Recall reflects the <em>sensitivity</em> of the model in detecting ground-truth objects. Similar to precision, recall can also be expressed as percentange, or value between $$0$$ and $$1$$.
 
 ### Interpretations of Precision-Recall
@@ -89,41 +93,51 @@ We can see that $$\mathrm{TP}(\tau)$$ and $$\mathrm{FP}(\tau)$$ are decreasing f
 </figure>
 
 The average precision is the area under the precision-recall curve, and is formally defined as
-<div class="block-equation">
-  $$\mathrm{AP} = \displaystyle \int p(\tau) d\tau $$
-</div>
+
+$$
+\mathrm{AP} = \displaystyle \int p(\tau) d\tau
+$$
 
 In practice, the precision-recall is often of zigzag-like shape, making it challenging to evaluate this integral. To circumvent this issue, the precision-recall curve is often first smoothed using either 11-point interpolation or all-point interpolation.
 
 ### 11-point interpolation
 
 In this method, the precision-recall curve is summarized by averaging the maximum precision values at a set of 11 equally spaced recal levels $$[0, 0.1, 0.2, \dots, 1]$$ , as given by
-<div class="block-equation">
-  $$\displaystyle \mathrm{AP}_{11} = \frac{1}{11} \underset{R \in \{0, 0.1, 0.2, \dots, 0.9, 1 \}}{\sum} P_{\mathrm{interp}} (R)$$
-</div>
+
+$$
+\displaystyle \mathrm{AP}_{11} = \frac{1}{11} \underset{R \in \{0, 0.1, 0.2, \dots, 0.9, 1 \}}{\sum} P_{\mathrm{interp}} (R)
+$$
+
 where $$ P_{\mathrm{interp}} (R)$$ is the interpolated precision at recall $$R$$, and is defined as
-<div class="block-equation">
-  $$\displaystyle P_{\mathrm{interp}} (R) = \underset{\tilde{R}:\tilde{R} \geq R}{\max} P\left( \tilde{R} \right)$$
-</div>
+
+$$
+\displaystyle P_{\mathrm{interp}} (R) = \underset{\tilde{R}:\tilde{R} \geq R}{\max} P\left( \tilde{R} \right)
+$$
+
 What it means is that instead of using the $$P(R)$$ at every observed recall level, the AP is obtained by considering the maximum precision $$ P_{\mathrm{interp}} (R)$$ whose recall value is greater than $$R$$.
 
 ### All-point interpolation
 
 In this approach, instead of taking only serveral points into consideration, the AP is computed by interpolating at each recall level, taking the maximum precision whose recall value is greater than or equal to $$R_{n+1}$$.
-<div class="block-equation">
-  $$\displaystyle \mathrm{AP}_{\mathrm{all}} = \sum_n \left( R_{n+1} - R_n \right) P_{\mathrm{interp}} (R_{n+1})$$
-</div>
+
+$$
+\displaystyle \mathrm{AP}_{\mathrm{all}} = \sum_n \left( R_{n+1} - R_n \right) P_{\mathrm{interp}} (R_{n+1})
+$$
+
 where
-<div class="block-equation">
-  $$\displaystyle P_{\mathrm{interp}} (R_{n+1}) = \underset{\tilde{R}:\tilde{R} \geq R_{n+1}}{\max} P\left( \tilde{R} \right) $$
-</div>
+
+$$
+\displaystyle P_{\mathrm{interp}} (R_{n+1}) = \underset{\tilde{R}:\tilde{R} \geq R_{n+1}}{\max} P\left( \tilde{R} \right)
+$$
 
 ## mean Average Precision - mAP
 
 The AP is often computed separately for each object class; then, the final performance of a detection model is often reported by taking the average over all classes, or, to obtain the mean average precision - mAP.
-<div class="block-equation">
-  $$\displaystyle \mathrm{mAP} = \frac{1}{N} \sum_{i=1}^N \mathrm{AP}_i$$
-</div>
+
+$$
+\displaystyle \mathrm{mAP} = \frac{1}{N} \sum_{i=1}^N \mathrm{AP}_i
+$$
+
 where $$\mathrm{AP}_i$$ is the average precision for the $$i$$th class.
 
 ## Object detection challenges and their APs
@@ -152,14 +166,20 @@ Object detection is a very active field of research, especially with the flouris
           <tr class="text-center">
             <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">MSCOCO
             </td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">$$\mathrm{AP}@[.5:.05:.95]; AP@50; AP@75; \mathrm{AP}_S; \mathrm{AP}_M; \mathrm{AP}_L$$
-            </td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">
+
+$$\mathrm{AP}@[.5:.05:.95]; AP@50; AP@75; \mathrm{AP}_S; \mathrm{AP}_M; \mathrm{AP}_L$$
+
+</td>
           </tr>
           <tr class="text-center">
             <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">ImageNet
             </td>
-            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">$$\mathrm{mAP} (\mathrm{IoU} = 0.5)$$
-            </td>
+            <td class="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">
+
+$$\mathrm{mAP} (\mathrm{IoU} = 0.5)$$
+
+</td>
           </tr>
         </tbody>
       </table>

--- a/src/content/machine-learning/ml4d-gradient-descent.md
+++ b/src/content/machine-learning/ml4d-gradient-descent.md
@@ -11,9 +11,15 @@ From an optimization point of view, deep learning is mostly about solving a larg
 
 ## Gradient Descent through a not-very-simple example
 Generally, gradient descent is an algorithm for finding the local minimum of a differential function by taking repated steps in the opposite direction of the gradient of that function. Assume that our function $$f$$ is parameterized by $$\mathbf{w}$$, or  a set of weights. The algorithm is as simple as
-<div class="block-equation">
-  $$\text{Repeat until convergence} \quad \{ \\\\ \qquad \mathbf{w} = \mathbf{w} - \eta * \nabla f\left(\mathbf{w}\right) \\\\ \}$$
-</div>
+
+$$
+\begin{aligned}
+&\text{Repeat until convergence} \quad \{ \\
+&\qquad \mathbf{w} = \mathbf{w} - \eta * \nabla f\left(\mathbf{w}\right) \\
+&\}
+\end{aligned}
+$$
+
 where
 
 * $$\mathbf{w}$$: the parameters we're updating
@@ -29,9 +35,11 @@ A natural set of questions one would ask with this description of the algorithm 
 These are all valid questions and seeking the answers to those questions will help us understand gradient descent. Let's try to find the answers (or part of them) for those questions through a simple example.
 
 We will use gradient descent to find the minimum of the following function
-<div class="block-equation">
-  $$f(w) = \frac{1}{50} \left( w^4 + w^2 + 10w \right)$$
-</div>
+
+$$
+f(w) = \frac{1}{50} \left( w^4 + w^2 + 10w \right)
+$$
+
 This function is indeed a simple one that, in reality, we would hardly see any loss function as simple as this for neural networks. It is a convex function, so it has a global minimum. It is not very simple in the sense that it probably takes more than 30 seconds for you to find the value of $$w$$ corresponding to the global minimum of the function.
 
 <figure class="figure mx-auto w-full md:w-3/5 p-2 flex flex-col items-center">
@@ -40,32 +48,45 @@ This function is indeed a simple one that, in reality, we would hardly see any l
 
 ### Finding the minimum with calculus
 If you recall some calculus knowledge from high school, you can see that $$f(w)$$ is determined for all $$w \in \mathbb{R}$$, i.e., the function is continuous, so it has derivates at all points within its domain. The first-order and second-order derivates of the function are
-<div class="block-equation">
-  $$\begin{aligned} f'\left( w \right) &= \frac{1}{50} \left( 4w^3 + 2w + 10 \right) \\\\ f''\left(w\right) &= \frac{1}{50} \left( 12w^2 + 2\right) \end{aligned}$$
-</div>
+
+$$
+\begin{aligned} f'\left( w \right) &= \frac{1}{50} \left( 4w^3 + 2w + 10 \right) \\ f''\left(w\right) &= \frac{1}{50} \left( 12w^2 + 2\right) \end{aligned}
+$$
 
 As $$f''(w) > 0$$ for all $$w \in \mathbb{R}$$, we are convinced that $$f$$ is a convex function. Furthermore, as the function has both first-order and second-order deratives determined at all points, there exists points $$w^*$$ such that
-<div class="block-equation">
-  $$\begin{cases} f'(w^*) = 0\\\\ f''(w^*) > 0\end{cases}$$
-</div>
+
+$$
+\begin{cases} f'(w^*) = 0\\ f''(w^*) > 0\end{cases}
+$$
+
 and the function $$f$$ has its minimum at $$w = w^*$$. Since $$f''(w) > 0$$, to find $$w^*$$, we only need to solve
-<div class="block-equation">
-  $$f'(w) = \frac{1}{50} \left( 4w^3 + 2w + 10 \right) = 0$$
-</div>
+
+$$
+f'(w) = \frac{1}{50} \left( 4w^3 + 2w + 10 \right) = 0
+$$
+
 I'm not going to devise the steps to solve this problem so that you will not feel that this article is about high-school calculus, not gradient descent. You can convince yourself <a href="https://www.wolframalpha.com/input?i=solve+1%2F50+%284x%5E3+%2B+2x+%2B+10%29+%3D+0" target="_blank">here</a> that $$f'(w) = 0$$ has a unique solution
-<div class="block-equation">
-  $$w^* = \displaystyle \frac{ \sqrt[3]{ \sqrt{2031} - 45 } }{6^{\frac{2}{3}}} - \frac{1}{\sqrt[3]{6 \left(\sqrt{2031} - 45\right)}} \approx -1.2347824$$
-</div>
+
+$$
+w^* = \displaystyle \frac{ \sqrt[3]{ \sqrt{2031} - 45 } }{6^{\frac{2}{3}}} - \frac{1}{\sqrt[3]{6 \left(\sqrt{2031} - 45\right)}} \approx -1.2347824
+$$
+
 This is why I've told you it is unlikely to get the solution in 30 seconds if you do it by hands. Anyway, our function $$f$$ has a global minimum
-<div class="block-equation">
-  $$\min f(w) \approx -0.1699692 \quad \text{at}~w \approx -1.2347824$$
-</div>
+
+$$
+\min f(w) \approx -0.1699692 \quad \text{at}~w \approx -1.2347824
+$$
 
 ### Finding the minimum with gradient descent
 Let's find the minimum of $$f$$ with gradient descent, and see if we would end up at the same solution above. Until now, I haven't told you what "convergence" means, so we modify our algorithm a bit by repeating the update step for $$N$$ times. Our algorithm now looks like this
-<div class="block-equation">
-  $$w_0 = \text{a random value}\\\\ \text{for}~i = 1 \dots N:\\\\ \qquad w_i = w_{i-1} - \eta * \nabla f\left(w_{i-1}\right)$$
-</div>
+
+$$
+\begin{aligned}
+&w_0 = \text{a random value} \\
+&\text{for}~i = 1 \dots N: \\
+&\qquad w_i = w_{i-1} - \eta * \nabla f\left(w_{i-1}\right)
+\end{aligned}
+$$
 
 We can implement this simple algorithm in <a href="https://jax.readthedocs.io/en/latest/index.html" target="_blank">Jax</a>. Jax provides a convenient function `grad` to compute the gradient of an arbitarity function w.r.t. some input.
 
@@ -146,7 +167,11 @@ A saddle point is a point where it's minimum in one direction, and local maximum
 
 <figure class="figure mx-auto w-full md:w-3/5 flex flex-col items-center">
   <img src="/images/machine-learning/20221006_gradient_descent_saddle_point.png" />
-  <figcaption>$$(x, y) = (0, 0)$$ is a saddle point for $$f(x, y) = x^2 - y^2$$</figcaption>
+  <figcaption>
+
+$$(x, y) = (0, 0)$$ is a saddle point for $$f(x, y) = x^2 - y^2$$
+
+</figcaption>
 </figure>
 
 ## Variants of gradient descent
@@ -161,23 +186,21 @@ The rescue to those problems is to introduce randomness to the process.
 In this approach, instead of updating the parameter based on the gradient of all training examples, we update the parameter using the gradient computed from a single training example at each step, and we do this for all examples in our training dataset. In doing so, we introduce some sorts of randomness to the gradient descent. Indeed, we select one sample at a time, randomly, and calculate the gradient of the loss function w.r.t to the parameters. This gradient is an estimation of the actual gradient (computed on the entire dataset).
 
 The pseudo-code for the algorithm can be rewritten as below
+
 <div class="algorithm-block font-sans text-md rounded-xl overflow-auto bg-slate-100 border border-black/5 mb-2">
-  <div class="title p-2 bg-sky-100 text-sky-800 font-bold">Stochastic Gradient Descent</div>
-  <div class="content">
-    <ul>
-      <li>Initialize parameters $$\mathbf{w}$$</li>
-      <li>
-        <div class="mb-0">Repeat until convergence</div>
-        <ul>
-          <li>Randomly shuffle the training data</li>
-          <li>For $$i = 1\dots N$$:</li>
-          <ul>
-            <li>$$\mathbf{w} = \mathbf{w} - \eta * \nabla \mathcal{L}_i \left( \mathbf{w} \right)$$</li>
-          </ul>
-        </ul>
-      </li>
-    </ul>
-  </div>
+
+<div class="title p-2 bg-sky-100 text-sky-800 font-bold">Stochastic Gradient Descent</div>
+
+<div class="content p-4">
+
+- Initialize parameters $$\mathbf{w}$$
+- Repeat until convergence
+    - Randomly shuffle the training data
+    - For $$i = 1\dots N$$:
+        - $$\mathbf{w} = \mathbf{w} - \eta * \nabla \mathcal{L}_i \left( \mathbf{w} \right)$$
+
+</div>
+
 </div>
 
 The gradient estimated from a single example might be slightly different from the actual gradient. Therefore, when the batch gradient desccent is stuck at some local minimum, stochastic gradient descent might steer the update in a slightly different direction, which helps us get out of that minimum region. Stochastic gradient descent (SGD) trades faster iteration speed for slow convergence since we have to do multiple update steps per epoch.

--- a/src/content/machine-learning/ml4d-linear-regression.md
+++ b/src/content/machine-learning/ml4d-linear-regression.md
@@ -12,9 +12,11 @@ Linear regression is the simplest method for regression analysis. With current s
 ## Formulation
 ### Problem statement
 Linear regression is a supervised learning method that learns to model a dependent variable $$y$$ as a function of some independent variables, a.k.a, **features**, by finding the straight line that best fits the data. The data for linear regression comes as input/output pairs
-<div class="block-equation">
-  $$\mathcal{D} = \{ \left( \mathbf{x_1}, y_1 \right), \left( \mathbf{x_2}, y_2 \right), \dots, \left( \mathbf{x_N}, y_N \right)\}$$
-</div>
+
+$$
+\mathcal{D} = \{ \left( \mathbf{x_1}, y_1 \right), \left( \mathbf{x_2}, y_2 \right), \dots, \left( \mathbf{x_N}, y_N \right)\}
+$$
+
 where each input sample $$\mathbf{x}_i$$ is a vector of $$p$$ features, and the ouput $$y_i$$ is scalar-valued. In the simplest case, $$p = 1$$, i.e., the input has one feature, linear regression is like to drawing a straight trend line in a scatter plot. In general, however, $$p > 1$$ in which case the linear regression problem is analogous to fitting a hyperplane to a scatter points in $$p + 1$$ dimensional space.
 
 <figure class="figure mx-auto w-full md:w-3/5 p-2 flex flex-col items-center">
@@ -24,28 +26,34 @@ where each input sample $$\mathbf{x}_i$$ is a vector of $$p$$ features, and the 
 
 <br />
 Generally, the equation for linear regression for each data point is
-<div class="block-equation">
-  $$y = w_0 + w_1 x_1 + w_2 x_2 + \dots + w_p x_p + \epsilon$$
-</div>
+
+$$
+y = w_0 + w_1 x_1 + w_2 x_2 + \dots + w_p x_p + \epsilon
+$$
+
 where $$w_j$$ is the coefficient of the model. The first coefficient $$w_0$$ is often called the *intercept* of the model. $$\epsilon$$ is the irreducable error that cannot be expressed by our model. As a side note, other people might denote the coefficient as $$\beta_j$$.
 
 Since we have $$N$$ data points, the equation is often written in matrix form
-<div class="block-equation">
-  $$\mathbf{y} = \mathbf{XW} + \mathbf{\epsilon}$$
-</div>
+
+$$
+\mathbf{y} = \mathbf{XW} + \mathbf{\epsilon}
+$$
+
 where $$X$$ is the matrix of input data, and $$\mathbf{W}$$ is the coefficient matrix, or the weight matrix. You might have realized that there is something off about this equation. $$X$$ is of dimension $$(N, p)$$, while $$\mathbf{W}$$ is of the dimension $$(p+1,)$$; hence, matrix multiplication won't work here. To solve this issue, we can insert a constant $$1$$ as the first column of the matrix $$\mathbf{X}$$. And now our matrices look like followings
 
-<div class="block-equation">
-$$\mathbf{X} = \begin{bmatrix} 1 & x_{11} & x_{12} & \dots & x_{1p} \\\\ 1 & x_{21} & x_{22} & \dots & x_{2p}\\\\ \vdots & \vdots & \vdots & \ddots & \vdots \\\\ 1 & x_{N1} & x_{N2} & \dots & x_{Np} \end{bmatrix}$$ $$\quad \mathbf{W} = \begin{bmatrix} \beta_0 \\\\ \beta_1 \\\\ \vdots \\\\ \beta_p \end{bmatrix}$$ $$\quad \mathbf{y} = \begin{bmatrix} y_1 \\\\ y_2 \\\\ \vdots \\\\ y_N \end{bmatrix}$$ $$\quad \mathbf{\epsilon} = \begin{bmatrix} \epsilon_1 \\\\ \epsilon_2 \\\\ \vdots \\\\ \epsilon_N \end{bmatrix}$$
-</div>
+$$
+\mathbf{X} = \begin{bmatrix} 1 & x_{11} & x_{12} & \dots & x_{1p} \\ 1 & x_{21} & x_{22} & \dots & x_{2p}\\ \vdots & \vdots & \vdots & \ddots & \vdots \\ 1 & x_{N1} & x_{N2} & \dots & x_{Np} \end{bmatrix} \quad \mathbf{W} = \begin{bmatrix} \beta_0 \\ \beta_1 \\ \vdots \\ \beta_p \end{bmatrix} \quad \mathbf{y} = \begin{bmatrix} y_1 \\ y_2 \\ \vdots \\ y_N \end{bmatrix} \quad \mathbf{\epsilon} = \begin{bmatrix} \epsilon_1 \\ \epsilon_2 \\ \vdots \\ \epsilon_N \end{bmatrix}
+$$
 
 Fitting a linear regression model is all about finding the best weights $$\mathbf{W}$$ that best model $$y$$ as a function of the input features. While we might never find the "true" weights, we can estimate them. We are going to look into two methods for estimating the weights below. But first, let's look at the loss function for our linear regression model.
 
 ### Loss function
 The loss function quantifies how good or bad our linear regression model is. To train the model, we employ the **mean squared error** (MSE) as our loss function.
-<div class="block-equation">
-  $$\displaystyle MSE = \mathcal{L}\left(\mathbf{W}\right) = \frac{1}{2} \sum_{i=1}^N \left\vert y_i - \sum_{j=0}^p x_{ij} w_{j} \right\vert ^2 = \frac{1}{2} \lVert \mathbf{y} - \mathbf{X W} \rVert ^2_2 $$
-</div>
+
+$$
+\displaystyle MSE = \mathcal{L}\left(\mathbf{W}\right) = \frac{1}{2} \sum_{i=1}^N \left\vert y_i - \sum_{j=0}^p x_{ij} w_{j} \right\vert ^2 = \frac{1}{2} \lVert \mathbf{y} - \mathbf{X W} \rVert ^2_2
+$$
+
 We add a constant $$\frac{1}{2}$$ to the equation above to simplify the calculation of the gradient of this loss function, as shall be shown below. The square of the errors give more weight to points that are further from the regression line, thus, punishing more the outliners.
 
 <figure class="figure mx-auto w-full md:w-3/5 p-2 flex flex-col items-center">
@@ -54,38 +62,47 @@ We add a constant $$\frac{1}{2}$$ to the equation above to simplify the calculat
 </figure>
 
 The optimal set of weights $$\mathbf{\hat{W}}$$ is the one that minize the loss function.
-<div class="block-equation">
-  $$\hat{\mathbf{W}} = \underset{\mathbf{W}}{\arg\min}~ \mathcal{L}\left(\mathbf{W}\right)$$
-</div>
 
+$$
+\hat{\mathbf{W}} = \underset{\mathbf{W}}{\arg\min}~ \mathcal{L}\left(\mathbf{W}\right)
+$$
 
 Our MSE loss function is a convex function; hence, we can find the optimal weights that minize the loss using methods such as Ordinary Least Squares (OLS) or Gradient Descent (GD).
 
 ### Parameter estimation with Ordinary Least Squares
 Let's look closer at the loss function
-<div class="block-equation">
-  $$\begin{aligned} \mathcal{L}\left(\mathbf{W}\right) &= \frac{1}{2} \lVert \mathbf{y} - \mathbf{X W} \rVert ^2_2 \\\\ &= \frac{1}{2} \left(\mathbf{y} - \mathbf{X W}\right)^{\top} \left(\mathbf{y} - \mathbf{X W}\right) \\\\ &= \frac{1}{2} \left(\mathbf{y}^{\top} - \mathbf{W}^{\top}\mathbf{X}^{\top} \right) \left(\mathbf{y} - \mathbf{X W}\right) \\\\ &= \frac{1}{2} \left(\mathbf{y}^{\top}\mathbf{y} - \mathbf{y}^{\top}\mathbf{XW} - \mathbf{W}^{\top}\mathbf{X}^{\top}\mathbf{y} + \mathbf{W}^{\top}\mathbf{X}^{\top}\mathbf{X W}\right)\end{aligned}$$
-</div>
+
+$$
+\begin{aligned} \mathcal{L}\left(\mathbf{W}\right) &= \frac{1}{2} \lVert \mathbf{y} - \mathbf{X W} \rVert ^2_2 \\ &= \frac{1}{2} \left(\mathbf{y} - \mathbf{X W}\right)^{\top} \left(\mathbf{y} - \mathbf{X W}\right) \\ &= \frac{1}{2} \left(\mathbf{y}^{\top} - \mathbf{W}^{\top}\mathbf{X}^{\top} \right) \left(\mathbf{y} - \mathbf{X W}\right) \\ &= \frac{1}{2} \left(\mathbf{y}^{\top}\mathbf{y} - \mathbf{y}^{\top}\mathbf{XW} - \mathbf{W}^{\top}\mathbf{X}^{\top}\mathbf{y} + \mathbf{W}^{\top}\mathbf{X}^{\top}\mathbf{X W}\right)\end{aligned}
+$$
+
 Since the loss function is convex, the optimum solution lies at gradient zero. So now we derive the gradient of the loss function w.r.t to $$\mathbf{W}$$
-<div class="block-equation">
-  $$\begin{aligned}\displaystyle \frac{\partial \mathcal{L}}{\partial \mathbf{W}} &= \frac{1}{2} \frac{\partial \left( \mathbf{y}^{\top}\mathbf{y} - \mathbf{y}^{\top}\mathbf{XW} - \mathbf{W}^{\top}\mathbf{X}^{\top}\mathbf{y} + \mathbf{W}^{\top}\mathbf{X}^{\top}\mathbf{X W} \right)}{\partial \mathbf{W}} \\\\ &= \frac{1}{2} \left( -\mathbf{y}^{\top}\mathbf{X} - \mathbf{X}^{\top}\mathbf{y} + 2\mathbf{X}^{\top}\mathbf{X W} \right) \\\\ &= \frac{1}{2} \left( -2\mathbf{X}^{\top}\mathbf{y} + 2\mathbf{X}^{\top}\mathbf{X W} \right) \\\\ &=  \mathbf{X}^{\top}\mathbf{y} + \mathbf{X}^{\top}\mathbf{X W} \end{aligned}$$
-</div>
+
+$$
+\begin{aligned}\displaystyle \frac{\partial \mathcal{L}}{\partial \mathbf{W}} &= \frac{1}{2} \frac{\partial \left( \mathbf{y}^{\top}\mathbf{y} - \mathbf{y}^{\top}\mathbf{XW} - \mathbf{W}^{\top}\mathbf{X}^{\top}\mathbf{y} + \mathbf{W}^{\top}\mathbf{X}^{\top}\mathbf{X W} \right)}{\partial \mathbf{W}} \\ &= \frac{1}{2} \left( -\mathbf{y}^{\top}\mathbf{X} - \mathbf{X}^{\top}\mathbf{y} + 2\mathbf{X}^{\top}\mathbf{X W} \right) \\ &= \frac{1}{2} \left( -2\mathbf{X}^{\top}\mathbf{y} + 2\mathbf{X}^{\top}\mathbf{X W} \right) \\ &=  \mathbf{X}^{\top}\mathbf{y} + \mathbf{X}^{\top}\mathbf{X W} \end{aligned}
+$$
+
 Solve this equation equals to $$0$$, we get
-<div class="block-equation">
-  $$\begin{aligned} -\mathbf{X}^{\top}\mathbf{y} + \mathbf{X}^{\top}\mathbf{X W} &= 0 \\\\ \mathbf{X}^{\top}\mathbf{X W} &= \mathbf{X}^{\top}\mathbf{y} \\\\ \mathbf{W} &=  \left(\mathbf{X}^{\top}\mathbf{X}\right)^{-1}\mathbf{X}^{\top}\mathbf{y} \end{aligned}$$
-</div>
+
+$$
+\begin{aligned} -\mathbf{X}^{\top}\mathbf{y} + \mathbf{X}^{\top}\mathbf{X W} &= 0 \\ \mathbf{X}^{\top}\mathbf{X W} &= \mathbf{X}^{\top}\mathbf{y} \\ \mathbf{W} &=  \left(\mathbf{X}^{\top}\mathbf{X}\right)^{-1}\mathbf{X}^{\top}\mathbf{y} \end{aligned}
+$$
+
 If you're still mathematically curious, we can use the Gauss-Markov theorem to prove that the set of coefficients $$\mathbf{W}$$ obtained in the equation above is optimal.
 
 ### Parameter estimation with Gradient Descent
 Again, as the MSE loss function is a convex function; GD can have a chance to find the optimal minimum. Let's modify the equation for the gradient a bit
-<div class="block-equation">
-  $$\begin{aligned}\displaystyle \frac{\partial \mathcal{L}}{\partial \mathbf{W}} &= -\mathbf{X}^{\top}\mathbf{y} + \mathbf{X}^{\top}\mathbf{X W} \\\\ \nabla \mathbf{W} &= -\mathbf{X}^{\top} \left(\mathbf{y} + \mathbf{XW} \right) = -\left( \mathbf{XW} - \mathbf{y} \right)^{\top} \mathbf{X} \\\\ \nabla \mathbf{W} &= \left(\hat{\mathbf{y}} - \mathbf{y}\right)^{\top}\mathbf{X}\end{aligned}$$
-</div>
+
+$$
+\begin{aligned}\displaystyle \frac{\partial \mathcal{L}}{\partial \mathbf{W}} &= -\mathbf{X}^{\top}\mathbf{y} + \mathbf{X}^{\top}\mathbf{X W} \\ \nabla \mathbf{W} &= -\mathbf{X}^{\top} \left(\mathbf{y} + \mathbf{XW} \right) = -\left( \mathbf{XW} - \mathbf{y} \right)^{\top} \mathbf{X} \\ \nabla \mathbf{W} &= \left(\hat{\mathbf{y}} - \mathbf{y}\right)^{\top}\mathbf{X}\end{aligned}
+$$
 
 Having devised the gradient of our loss function, the update equation of the GD algorithm is
-<div class="block-equation">
-  $$\mathbf{W} = \mathbf{W} - \eta * \left( \hat{\mathbf{y}} - \mathbf{y} \right)^{\top} \mathbf{W}$$
-</div>
+
+$$
+\mathbf{W} = \mathbf{W} - \eta * \left( \hat{\mathbf{y}} - \mathbf{y} \right)^{\top} \mathbf{W}
+$$
+
 where $$\eta$$ is the learning rate.
 
 ### Assumptions of Linear Regression model

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import MetaInfo from '../components/MetaInfo.astro';
 import SiteHeader from '../components/SiteHeader.astro';
 import SiteFooter from '../components/SiteFooter.astro';
 import '../styles/global.css';
+import 'katex/dist/katex.min.css';
 
 import site from '../data/site.json';
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,10 +19,6 @@
   @apply text-rose-600 transition-all duration-100;
 }
 
-.block-equation {
-  @apply flex justify-center py-4;
-}
-
 /*
  * Format markdown post content
  */


### PR DESCRIPTION
## Summary
- Display equations across the math posts were not rendering: `<div class="block-equation">` is a CommonMark raw HTML block, so the `$$…$$` inside (and prose on the line right after `</div>`) never reached `remark-math`. All 28 display equations across `ml4d-linear-regression`, `ml4d-gradient-descent`, and `evaluate-object-detection-models` were affected, plus a chunk of inline math that happened to follow a `</div>` without a blank-line separator.
- Matrix and aligned-block line breaks were written as `\\\\` (a holdover from a prior markdown processor that pre-processed backslashes). Under `remark-math` v6 those reach KaTeX literally as four backslashes, which is not the row-break command — even after fix #1, matrices wouldn't render correctly until this was addressed.
- KaTeX CSS now bundles via `import 'katex/dist/katex.min.css'` in `Base.astro` instead of loading from `cdn.jsdelivr.net` with an SRI hash that had to be manually kept in sync on every version bump.
- `rehype-katex` is now configured with `{ throwOnError: true, strict: 'error' }`, so any future invalid TeX fails the build instead of silently rendering as raw text.

## Test plan
- [x] `yarn build` succeeds with strict KaTeX errors enabled
- [x] Linear-regression post: 27 KaTeX spans, 11 display equations, 0 unparsed `$$`
- [x] Gradient-descent post: 35 KaTeX spans, 8 display equations, 0 unparsed `$$` (incl. SGD pseudocode block rewritten as nested markdown lists)
- [x] Object-detection post: 27 KaTeX spans, 9 display equations, 0 unparsed `$$`
- [x] KaTeX font files now bundled in `dist/_astro/` (verified `KaTeX_AMS-Regular.*.woff2` etc. are present); no CDN reference in built HTML
- [ ] Visual smoke test in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)