### PR TITLE
Add in-progress status indicator to todo items

### DIFF
--- a/src/data/todo100.json
+++ b/src/data/todo100.json
@@ -216,12 +216,14 @@
     {
       "order": 41,
       "text": "Be supportive",
-      "done": false
+      "done": false,
+      "inProgress": true
     },
     {
       "order": 42,
       "text": "Be nice",
-      "done": false
+      "done": false,
+      "inProgress": true
     },
     {
       "order": "xx",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -8,6 +8,7 @@ interface TodoItem {
   text: string;
   subText?: string;
   done: boolean;
+  inProgress?: boolean;
 }
 
 const items = todo100.items as TodoItem[];
@@ -68,6 +69,12 @@ const items = todo100.items as TodoItem[];
               <span class="text-green-400 w-8">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                   <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                </svg>
+              </span>
+            ) : item.inProgress ? (
+              <span class="text-blue-500 w-8">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M6 10a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zm5.5 0a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM15.5 11.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z" />
                 </svg>
               </span>
             ) : (


### PR DESCRIPTION
## Summary
Added support for tracking items that are currently in progress on the todo list. Items marked with `inProgress: true` now display a visual indicator (three-dot loading icon) distinct from completed items.

## Changes
- **TypeScript interface**: Added optional `inProgress?: boolean` property to `TodoItem` interface in `src/pages/about.astro`
- **UI indicator**: Implemented conditional rendering to display a blue three-dot icon for in-progress items, positioned between the completed checkmark and empty state
- **Data**: Marked two todo items as in progress:
  - "Be supportive" (order 41)
  - "Be nice" (order 42)

## Implementation Details
The in-progress state uses a three-dot loading SVG icon styled in blue (`text-blue-500`) to visually distinguish it from completed items (green checkmark) and pending items (empty space). The conditional rendering follows the existing pattern: `done` → `inProgress` → empty state.

https://claude.ai/code/session_01QL4MbY8imS9hkjQQ9TzAqb